### PR TITLE
[u-mr1] PlatformConfig: Add androidboot.usbcontroller to boot command line

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -34,6 +34,8 @@ BOARD_KERNEL_CMDLINE += console=null
 # Serial console
 #BOARD_KERNEL_CMDLINE += earlycon=msm_geni_serial,0x4c8c000
 
+BOARD_BOOTCONFIG += androidboot.usbcontroller=a600000.dwc3
+
 TARGET_RECOVERY_WIPE := $(PLATFORM_COMMON_PATH)/rootdir/recovery.wipe
 TARGET_RECOVERY_FSTAB ?= $(PLATFORM_COMMON_PATH)/rootdir/vendor/etc/fstab.columbia
 

--- a/platform.mk
+++ b/platform.mk
@@ -432,8 +432,8 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # USB controller setup
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.boot.usb.dwc3=4e00000.ssusb \
-    sys.usb.controller=4e00000.dwc3 \
+    ro.boot.usb.dwc3=a600000.ssusb \
+    sys.usb.controller=a600000.dwc3 \
     sys.usb.rndis.func.name=gsi
 
 #WiFi MAC address path


### PR DESCRIPTION
Add androidboot.usbcontroller to specify device node for USB
controller used to execute USB ConfigFS initialization
sequences for recovery boot.