### PR TITLE
[u-mr1] etc: init.columbia.rc: Bring WPSS out of reset

### DIFF
--- a/rootdir/vendor/etc/init/init.columbia.rc
+++ b/rootdir/vendor/etc/init/init.columbia.rc
@@ -47,6 +47,10 @@ on init
 on boot
     # WLAN MAC
     chown wifi wifi /sys/module/wlan/parameters/fwpath
+
+    # Bring WPSS out of reset
+    write /sys/kernel/icnss/wpss_boot 1
+
     # Trigger WLAN driver load
     write /sys/kernel/boot_wlan/boot_wlan 1
 


### PR DESCRIPTION
Auto boot for WPSS is disabled by default in Q6V5 PAS
driver, so it must be triggered from userspace.