### PR TITLE
[u-mr1] etc: ueventd.rc: Add permissions for remoteproc nodes

### DIFF
--- a/rootdir/vendor/etc/ueventd.rc
+++ b/rootdir/vendor/etc/ueventd.rc
@@ -163,6 +163,9 @@ subsystem mem_buf_vm
 # SSR devices
 /dev/subsys_*         0640   system     system
 
+# remoteproc devices
+/dev/remoteproc*          0640   system     system
+
 # BT
 /dev/hidraw*                                0666 system    system
 /dev/btpower                                0660 bluetooth bluetooth


### PR DESCRIPTION
Add permissions for the Peripheral Manager to access
remoteproc nodes in order to boot the modem.