### PR TITLE
platform: Set vendor.media.target_variant property

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -431,8 +431,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Media
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.media.xml_variant.codecs=_parrot_v1 \
-    ro.media.xml_variant.codecs_performance=_parrot_v1 \
+    vendor.media.target_variant=_parrot_v1 \
     vendor.mm.enable.qcom_parser=1040463
 
 $(call inherit-product, device/sony/common/common.mk)


### PR DESCRIPTION
This property is required by QTI C2. We will also use
this property to set the ro.media.xml_variant.(codecs/
codecs_performance/profiles) properties, since their
values ​​are always the same.